### PR TITLE
Nitpicked Underwater Wheel Optimizations

### DIFF
--- a/src/main/java/com/simibubi/create/content/contraptions/components/waterwheel/WaterWheelBlock.java
+++ b/src/main/java/com/simibubi/create/content/contraptions/components/waterwheel/WaterWheelBlock.java
@@ -93,14 +93,21 @@ public class WaterWheelBlock extends HorizontalKineticBlock implements ITE<Water
 			return;
 
 		FluidState fluid = world.getFluidState(pos.offset(f));
-		BlockState adjacentBlock = world.getBlockState(pos.offset(f));
 		Direction wf = state.get(HORIZONTAL_FACING);
 		boolean clockwise = wf.getAxisDirection() == AxisDirection.POSITIVE;
 		int clockwiseMultiplier = 2;
 
-		Vector3d vec = (adjacentBlock.getBlock() == Blocks.BUBBLE_COLUMN.getBlock() && f.getAxis().isHorizontal()) ?
-				new Vector3d(0.0, adjacentBlock.get(DRAG) ? -1.0 : 1.0, 0.0) :
-				fluid.getFlow(world, pos.offset(f));
+		Vector3d vec;
+		if (f.getAxis().isHorizontal()) {
+			BlockState adjacentBlock = world.getBlockState(pos.offset(f));
+			if (adjacentBlock.getBlock() == Blocks.BUBBLE_COLUMN.getBlock()) {
+				vec = new Vector3d(0.0, adjacentBlock.get(DRAG) ? -1.0 : 1.0, 0.0);
+			} else {
+				vec = fluid.getFlow(world, pos.offset(f));
+			}
+		} else {
+			vec = fluid.getFlow(world, pos.offset(f));
+		}
 		vec = vec.scale(f.getAxisDirection()
 			.getOffset());
 		vec = new Vector3d(Math.signum(vec.x), Math.signum(vec.y), Math.signum(vec.z));


### PR DESCRIPTION
- Replaced the conditional operator I previously used with a set of if statements
- Moved getting the BlockState such that it is only called when it absolutely needs to be called, within said if statements

...Basically, instead of getting the BlockState for all four effective sides it only gets it for the two horizontal sides where the bubble column check would be useful